### PR TITLE
Duracloud 1070 and 1120

### DIFF
--- a/common-taskproducer/src/main/java/org/duracloud/mill/common/taskproducer/TaskProducerConfigurationManager.java
+++ b/common-taskproducer/src/main/java/org/duracloud/mill/common/taskproducer/TaskProducerConfigurationManager.java
@@ -28,17 +28,6 @@ public class TaskProducerConfigurationManager extends ConfigurationManager {
         return System.getProperty(ConfigConstants.DUPLICATION_POLICY_BUCKET_SUFFIX);
     }
     
-    /**
-     * @return
-     */
-    public String[] getNotificationRecipients() {
-        String recipients =  System.getProperty(ConfigConstants.NOTIFICATION_RECIPIENTS);
-        if(StringUtils.isBlank(recipients)){
-            return null;
-        }else{
-            return recipients.split(",");
-        }
-    }
 
     /**
      * @return

--- a/common/src/main/java/org/duracloud/mill/config/ConfigConstants.java
+++ b/common/src/main/java/org/duracloud/mill/config/ConfigConstants.java
@@ -31,6 +31,7 @@ public class ConfigConstants {
      */
     public static final String WORK_DIRECTORY_PATH = "workdir";
     public static final String NOTIFICATION_RECIPIENTS = "notification.recipients";
+    public static final String NOTIFICATION_RECIPIENTS_NON_TECH = "notification.recipients.non-tech";
     public static final String NOTIFICATION_SENDER = "notification.sender";
 
     /*

--- a/common/src/main/java/org/duracloud/mill/config/ConfigConstants.java
+++ b/common/src/main/java/org/duracloud/mill/config/ConfigConstants.java
@@ -31,6 +31,7 @@ public class ConfigConstants {
      */
     public static final String WORK_DIRECTORY_PATH = "workdir";
     public static final String NOTIFICATION_RECIPIENTS = "notification.recipients";
+    public static final String NOTIFICATION_SENDER = "notification.sender";
 
     /*
      * AUDIT LOG GENERATOR

--- a/common/src/main/java/org/duracloud/mill/config/ConfigurationManager.java
+++ b/common/src/main/java/org/duracloud/mill/config/ConfigurationManager.java
@@ -7,6 +7,7 @@
  */
 package org.duracloud.mill.config;
 
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author Daniel Bernstein
@@ -24,5 +25,22 @@ public class ConfigurationManager {
 
     public String getWorkDirectoryPath() {
         return System.getProperty(ConfigConstants.WORK_DIRECTORY_PATH);
+    }
+    
+    public String[] getNotificationRecipients() {
+        return getCommaSeparatedListToArray(ConfigConstants.NOTIFICATION_RECIPIENTS);
+    }
+
+    private String[] getCommaSeparatedListToArray(String prop) {
+        String values =  System.getProperty(prop);
+        if(StringUtils.isBlank(values)){
+            return new String[0];
+        }else{
+            return values.split(",");
+        }
+    }
+    
+    public String[] getNotificationRecipientsNonTech() {
+        return getCommaSeparatedListToArray(ConfigConstants.NOTIFICATION_RECIPIENTS_NON_TECH);
     }
 }

--- a/common/src/main/java/org/duracloud/mill/notification/SESNotificationManager.java
+++ b/common/src/main/java/org/duracloud/mill/notification/SESNotificationManager.java
@@ -70,7 +70,7 @@ public class SESNotificationManager implements NotificationManager {
             Destination destination = new Destination();
             destination.setToAddresses(Arrays.asList(this.recipientEmailAddresses));
             email.setDestination(destination);
-            email.setSource("notifications@duracloud.org");
+            email.setSource(System.getProperty("notification.sender", "no-sender-specified"));
             Message message = new Message(new Content(subject), new Body(new Content(body)));
             email.setMessage(message);
             client.sendEmail(email);

--- a/common/src/main/java/org/duracloud/mill/util/PropertyDefinitionListBuilder.java
+++ b/common/src/main/java/org/duracloud/mill/util/PropertyDefinitionListBuilder.java
@@ -100,8 +100,10 @@ public class PropertyDefinitionListBuilder {
         return this;
     }
 
-    public PropertyDefinitionListBuilder addNotificationRecipients() {
+    public PropertyDefinitionListBuilder addNotifications() {
         add(ConfigConstants.NOTIFICATION_RECIPIENTS, true);
+        add(ConfigConstants.NOTIFICATION_SENDER, true);
+
         return this;
     }
 

--- a/common/src/main/java/org/duracloud/mill/util/PropertyDefinitionListBuilder.java
+++ b/common/src/main/java/org/duracloud/mill/util/PropertyDefinitionListBuilder.java
@@ -107,6 +107,11 @@ public class PropertyDefinitionListBuilder {
         return this;
     }
 
+    public PropertyDefinitionListBuilder addNotificationsNonTech() {
+        add(ConfigConstants.NOTIFICATION_RECIPIENTS_NON_TECH, false);
+        return this;
+    }
+
     public PropertyDefinitionListBuilder addStorageStatsQueue(){
         add(ConfigConstants.QUEUE_NAME_STORAGE_STATS, true);
         return this;

--- a/looping-storagestats-taskproducer/src/main/java/org/duracloud/mill/ltp/storagestats/AppDriver.java
+++ b/looping-storagestats-taskproducer/src/main/java/org/duracloud/mill/ltp/storagestats/AppDriver.java
@@ -83,7 +83,7 @@ public class AppDriver extends LoopingTaskProducerDriverSupport {
     protected LoopingTaskProducer buildTaskProducer() {
 
         List<PropertyDefinition> defintions = new PropertyDefinitionListBuilder().addAws()
-                .addNotificationRecipients()
+                .addNotifications()
                 .addMcDb()
                 .addLoopingStorageStatsFrequency()
                 .addLoopingStorageStatsMaxQueueSize()

--- a/loopingbittaskproducer/src/main/java/org/duracloud/mill/ltp/bit/AppDriver.java
+++ b/loopingbittaskproducer/src/main/java/org/duracloud/mill/ltp/bit/AppDriver.java
@@ -84,7 +84,7 @@ public class AppDriver extends LoopingTaskProducerDriverSupport {
     protected LoopingTaskProducer buildTaskProducer() {
 
         List<PropertyDefinition> defintions = new PropertyDefinitionListBuilder().addAws()
-                .addNotificationRecipients()
+                .addNotifications()
                 .addMcDb()
                 .addBitIntegrityQueue()
                 .addLoopingBitFrequency()

--- a/loopingduptaskproducer/src/main/java/org/duracloud/mill/ltp/dup/AppDriver.java
+++ b/loopingduptaskproducer/src/main/java/org/duracloud/mill/ltp/dup/AppDriver.java
@@ -64,7 +64,7 @@ public class AppDriver extends LoopingTaskProducerDriverSupport {
     protected LoopingTaskProducer buildTaskProducer() {
         
         List<PropertyDefinition> defintions = new PropertyDefinitionListBuilder().addAws()
-                .addNotificationRecipients()
+                .addNotifications()
                 .addMcDb()
                 .addDuplicationLowPriorityQueue()
                 .addLoopingDupFrequency()

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
     <module>taskproducertool</module>
     <module>taskreadertool</module>
     <module>policy-editor</module>
+    <module>storage-reporter</module>
   </modules>
 
   <profiles>

--- a/resources/mill-config-sample.properties
+++ b/resources/mill-config-sample.properties
@@ -55,8 +55,15 @@ queue.task.ordered=[]
 # Directory that will be used to temporarily store files as they are being processed.
 workdir=[]
 
-# A comma-separated list of email addresses
+# The email address of the notifications sender.
+notification.sender=[] 
+
+# A comma-separated list of email addresses to receive all notifications
 notification.recipients=[]
+
+# A comma-separated list of emails for non-technical support staff.
+# Only non-technical messages will be sent to these addresses.
+notification.recipients.non-tech=[]
 
 # Indicates that a local duplication policy directory should be used. - Optional, Primarily for development.
 #local-duplication-dir=/your/path/here

--- a/storage-reporter/pom.xml
+++ b/storage-reporter/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.duracloud.mill</groupId>
+  <artifactId>storage-reporter</artifactId>
+  <version>2.4.0-SNAPSHOT</version>
+  <name>DuraCloud Mill Storage Reporter</name>
+
+  <parent>
+    <artifactId>mill</artifactId>
+    <groupId>org.duracloud.mill</groupId>
+    <version>2.4.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <properties>
+    <!-- see maven-shade-plugin in root pom.xml -->
+    <mainClass>org.duracloud.mill.storagereporter.AppDriver</mainClass>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.duracloud.mill</groupId>
+      <artifactId>common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.duracloud.db</groupId>
+      <artifactId>mill-db-repo</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.duracloud.db</groupId>
+      <artifactId>account-management-db-repo</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/storage-reporter/src/main/assembly/dep.xml
+++ b/storage-reporter/src/main/assembly/dep.xml
@@ -1,0 +1,25 @@
+<assembly>
+  <id>driver</id>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <formats>
+    <format>jar</format>
+  </formats>
+
+  <fileSets>
+    <fileSet>
+      <directory>src/main/resources</directory>
+      <includes>
+        <include>*.properties</include>
+        <include>*.xml</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+
+  <dependencySets>
+    <dependencySet>
+      <unpack>true</unpack>
+    </dependencySet>
+  </dependencySets>
+
+</assembly>
+

--- a/storage-reporter/src/main/java/org/duracloud/mill/storagereporter/AccountStorageReportResult.java
+++ b/storage-reporter/src/main/java/org/duracloud/mill/storagereporter/AccountStorageReportResult.java
@@ -1,0 +1,68 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.mill.storagereporter;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.duracloud.account.db.model.AccountInfo;
+import org.duracloud.account.db.model.StorageProviderAccount;
+
+/**
+ * @author dbernstein 
+ * @since: Jun 28, 2017
+ */
+public class AccountStorageReportResult {
+
+    private List<StorageProviderResult> storageProviderResults = new LinkedList<>();
+    private AccountInfo account;
+    /**
+     * @param account
+     */
+    public AccountStorageReportResult(AccountInfo account) {
+        this.account = account;
+    }
+
+    /**
+     * @param storageProviderAccount
+     * @param total
+     */
+    public void addStorageProviderResult(
+                                         StorageProviderAccount storageProviderAccount,
+                                         long total) {
+        this.storageProviderResults.add(new StorageProviderResult(storageProviderAccount, total));
+    }
+
+    
+    /**
+     * @return
+     */
+    public boolean isOversubscribed() {
+        for(StorageProviderResult r : this.storageProviderResults){
+            if(r.isOversubscribed()){
+                return true;
+            }
+        }
+        
+        return false;
+    }
+
+    /**
+     * @return
+     */
+    public AccountInfo getAccount() {
+        return this.account;
+    }
+ 
+    /**
+     * @return the storageProviderResults
+     */
+    public List<StorageProviderResult> getStorageProviderResults() {
+        return storageProviderResults;
+    }
+}

--- a/storage-reporter/src/main/java/org/duracloud/mill/storagereporter/AppDriver.java
+++ b/storage-reporter/src/main/java/org/duracloud/mill/storagereporter/AppDriver.java
@@ -1,0 +1,80 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.mill.storagereporter;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.cli.CommandLine;
+import org.duracloud.account.db.repo.DuracloudAccountRepo;
+import org.duracloud.mill.config.ConfigurationManager;
+import org.duracloud.mill.db.repo.JpaSpaceStatsRepo;
+import org.duracloud.mill.notification.NotificationManager;
+import org.duracloud.mill.notification.SESNotificationManager;
+import org.duracloud.mill.util.CommonCommandLineOptions;
+import org.duracloud.mill.util.DriverSupport;
+import org.duracloud.mill.util.PropertyDefinition;
+import org.duracloud.mill.util.PropertyDefinitionListBuilder;
+import org.duracloud.mill.util.PropertyVerifier;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+/**
+ *  The main driver of the storage reporter tool.
+ * 
+ * @author dbernstein 
+ * @since: Jun 28, 2017
+ */
+public class AppDriver extends DriverSupport {
+
+    public AppDriver() {
+        super(new CommonCommandLineOptions());
+    }
+
+    public static void main(String[] args) {
+        new AppDriver().execute(args);
+    }
+
+    /**
+     * @param cmd
+     */
+    @Override
+    protected void executeImpl(CommandLine commandLine) {
+
+        List<PropertyDefinition> defintions = new PropertyDefinitionListBuilder().addAws()
+                                                                                 .addNotifications()
+                                                                                 .addNotificationsNonTech()
+                                                                                 .addMcDb()
+                                                                                 .addMillDb()
+                                                                                 .build();
+        PropertyVerifier verifier = new PropertyVerifier(defintions);
+        verifier.verify(System.getProperties());
+
+        // configure spring components
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext("org.duracloud.mill.db",
+                                                                                            "org.duracloud.account.db");
+        JpaSpaceStatsRepo statsRepo = (JpaSpaceStatsRepo) context
+                .getBean(JpaSpaceStatsRepo.class);
+        DuracloudAccountRepo accountRepo = (DuracloudAccountRepo) context
+                .getBean(DuracloudAccountRepo.class);
+
+        // setup notification client
+        ConfigurationManager configManager = new ConfigurationManager();
+        List<String> recipients = Arrays
+                .asList(configManager.getNotificationRecipients());
+        recipients.addAll(Arrays
+                .asList(configManager.getNotificationRecipientsNonTech()));
+        NotificationManager notification = new SESNotificationManager(recipients
+                .toArray(new String[0]));
+
+        StorageReporter reporter = new StorageReporter(statsRepo, accountRepo, notification);
+        reporter.run();
+        
+        context.close();
+    }
+}

--- a/storage-reporter/src/main/java/org/duracloud/mill/storagereporter/AppDriver.java
+++ b/storage-reporter/src/main/java/org/duracloud/mill/storagereporter/AppDriver.java
@@ -7,7 +7,7 @@
  */
 package org.duracloud.mill.storagereporter;
 
-import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.commons.cli.CommandLine;
@@ -21,7 +21,6 @@ import org.duracloud.mill.util.DriverSupport;
 import org.duracloud.mill.util.PropertyDefinition;
 import org.duracloud.mill.util.PropertyDefinitionListBuilder;
 import org.duracloud.mill.util.PropertyVerifier;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 /**
@@ -65,10 +64,15 @@ public class AppDriver extends DriverSupport {
 
         // setup notification client
         ConfigurationManager configManager = new ConfigurationManager();
-        List<String> recipients = Arrays
-                .asList(configManager.getNotificationRecipients());
-        recipients.addAll(Arrays
-                .asList(configManager.getNotificationRecipientsNonTech()));
+        List<String> recipients = new LinkedList<>();
+
+        for(String email : configManager.getNotificationRecipients()){
+            recipients.add(email);
+        }
+        for(String email : configManager.getNotificationRecipientsNonTech()){
+            recipients.add(email);
+        }
+
         NotificationManager notification = new SESNotificationManager(recipients
                 .toArray(new String[0]));
 

--- a/storage-reporter/src/main/java/org/duracloud/mill/storagereporter/StorageProviderResult.java
+++ b/storage-reporter/src/main/java/org/duracloud/mill/storagereporter/StorageProviderResult.java
@@ -1,0 +1,53 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.mill.storagereporter;
+
+import org.duracloud.account.db.model.StorageProviderAccount;
+
+/**
+ * 
+ * @author dbernstein 
+ * @since: Jun 28, 2017
+ */
+public class StorageProviderResult {
+    public static final long TB = 1000*1000*1000*1000l;
+    private long totalBytes;
+    private StorageProviderAccount storageProviderAccount;
+    /**
+     * @param storageProviderAccount
+     * @param totalBytes
+     */
+    public StorageProviderResult(StorageProviderAccount storageProviderAccount,
+                                 long totalBytes) {
+        this.totalBytes = totalBytes;
+        this.storageProviderAccount = storageProviderAccount;
+    }
+
+    /**
+     * @return the storageProviderAccount
+     */
+    public StorageProviderAccount getStorageProviderAccount() {
+        return storageProviderAccount;
+    }
+    
+    /**
+     * @return the totalBytes
+     */
+    public long getTotalBytes() {
+        return totalBytes;
+    }
+
+    /**
+     * @return
+     */
+    public boolean isOversubscribed() {
+        return totalBytes > storageProviderAccount.getStorageLimit()*TB;
+    }
+    
+}
+

--- a/storage-reporter/src/main/java/org/duracloud/mill/storagereporter/StorageReportResult.java
+++ b/storage-reporter/src/main/java/org/duracloud/mill/storagereporter/StorageReportResult.java
@@ -1,0 +1,45 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.mill.storagereporter;
+
+import java.util.List;
+
+/**
+ * @author danny
+ *         Date: Jun 29, 2017
+ */
+public class StorageReportResult {
+
+    private List<AccountStorageReportResult> oversubscribedAccounts;
+    private List<AccountStorageReportResult> undersubscribedAccounts; 
+
+    /**
+     * @param oversubscribedAccounts
+     * @param undersubscribedAccounts
+     */
+    public StorageReportResult(List<AccountStorageReportResult> oversubscribedAccounts,
+                               List<AccountStorageReportResult> undersubscribedAccounts) {
+        this.oversubscribedAccounts = oversubscribedAccounts;
+        this.undersubscribedAccounts = undersubscribedAccounts;
+    }
+    
+    /**
+     * @return the oversubscribedAccounts
+     */
+    public List<AccountStorageReportResult> getOversubscribedAccounts() {
+        return oversubscribedAccounts;
+    }
+    
+    /**
+     * @return the undersubscribedAccounts
+     */
+    public List<AccountStorageReportResult> getUndersubscribedAccounts() {
+        return undersubscribedAccounts;
+    }
+
+}

--- a/storage-reporter/src/main/java/org/duracloud/mill/storagereporter/StorageReporter.java
+++ b/storage-reporter/src/main/java/org/duracloud/mill/storagereporter/StorageReporter.java
@@ -124,8 +124,7 @@ public class StorageReporter {
         }
 
         // build subject
-        String subject = MessageFormat.format(
-                                              "Storage Report:  {0} Oversubscribed account(s)",
+        String subject = MessageFormat.format("DuraCloud Storage Report: {0} accounts over subscription limit",
                                               oversubscribedAccounts.size());
 
         StringBuilder body = new StringBuilder();

--- a/storage-reporter/src/main/java/org/duracloud/mill/storagereporter/StorageReporter.java
+++ b/storage-reporter/src/main/java/org/duracloud/mill/storagereporter/StorageReporter.java
@@ -1,0 +1,199 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.mill.storagereporter;
+
+import java.math.BigDecimal;
+import java.text.MessageFormat;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import org.duracloud.account.db.model.AccountInfo;
+import org.duracloud.account.db.model.AccountInfo.AccountStatus;
+import org.duracloud.account.db.model.StorageProviderAccount;
+import org.duracloud.account.db.repo.DuracloudAccountRepo;
+import org.duracloud.mill.db.repo.JpaSpaceStatsRepo;
+import org.duracloud.mill.notification.NotificationManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class contains the logic for generating storage reports. The storage
+ * report shows which accounts contain oversubscribed storage providers. An
+ * oversubscribed account is an account with at least one storage provider whose
+ * most recent byte count exceeds the allocation set on the storage provider's
+ * "storage limit" property. The report shows the total for each storage
+ * provider, the storage limit, and the % capacity of that storage provider.
+ * 
+ * @author dbernstein
+ * @since: Jun 29, 2017
+ */
+public class StorageReporter {
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(StorageReporter.class);
+
+    private JpaSpaceStatsRepo statsRepo;
+    private DuracloudAccountRepo accountRepo;
+    private NotificationManager notification;
+
+    /**
+     * @param statsRepo
+     * @param accountRepo
+     * @param notification
+     */
+    public StorageReporter(JpaSpaceStatsRepo statsRepo,
+                           DuracloudAccountRepo accountRepo,
+                           NotificationManager notification) {
+
+        this.statsRepo = statsRepo;
+        this.accountRepo = accountRepo;
+        this.notification = notification;
+    }
+
+    /**
+     * @return
+     * 
+     */
+    public StorageReportResult run() {
+        // for each active account
+        List<AccountStorageReportResult> oversubscribedAccounts = new LinkedList<>();
+        List<AccountStorageReportResult> undersubscribedAccounts = new LinkedList<>();
+
+        Date now = new Date();
+        Calendar c = Calendar.getInstance();
+        c.add(Calendar.MONTH, -1);
+        Date lastMonth = c.getTime();
+        List<AccountInfo> accounts = accountRepo
+                .findByStatus(AccountStatus.ACTIVE);
+        Collections.sort(accounts, new Comparator<AccountInfo>() {
+            @Override
+            public int compare(AccountInfo o1, AccountInfo o2) {
+                return o1.getAcctName().compareTo(o2.getAcctName());
+            }
+        });
+
+        for (AccountInfo account : accounts) {
+            String accountId = account.getSubdomain();
+            LOGGER.info("processing {}", accountId);
+            // gather all storage providers for an account into a single list.
+            StorageProviderAccount primary = account
+                    .getPrimaryStorageProviderAccount();
+            Set<StorageProviderAccount> secondary = account
+                    .getSecondaryStorageProviderAccounts();
+            List<StorageProviderAccount> providers = new LinkedList<>(secondary);
+            providers.add(0, primary);
+
+            AccountStorageReportResult result = new AccountStorageReportResult(account);
+
+            // for each storage provider
+            for (StorageProviderAccount storageProviderAccount : providers) {
+                List<Object[]> stats = statsRepo
+                        .getByAccountIdAndStoreId(accountId,
+                                                  storageProviderAccount.getId()
+                                                          + "",
+                                                  lastMonth,
+                                                  now,
+                                                  JpaSpaceStatsRepo.INTERVAL_DAY);
+                long total = 0;
+                if (stats != null && stats.size() > 0) {
+                    total = ((BigDecimal) stats.get(stats.size() - 1)[3])
+                            .longValue();
+                }
+                result.addStorageProviderResult(storageProviderAccount, total);
+            }
+
+            if (result.isOversubscribed()) {
+                oversubscribedAccounts.add(result);
+            } else {
+                undersubscribedAccounts.add(result);
+            }
+
+        }
+
+        // build subject
+        String subject = MessageFormat.format(
+                                              "Storage Report:  {0} Oversubscribed account(s)",
+                                              oversubscribedAccounts.size());
+
+        StringBuilder body = new StringBuilder();
+
+        if (oversubscribedAccounts.size() == 0) {
+            body.append("Presently there are no oversubscribed accounts.\n\n");
+        } else {
+            body.append("Oversubscribed Accounts: \n\n");
+        }
+        // write oversubscribed in initial block
+        for (AccountStorageReportResult result : oversubscribedAccounts) {
+            appendResultToBody(result, body);
+        }
+
+        body.append("\nAll other (ie undersubscribedAccounts) accounts: \n\n");
+
+        // write undersubscribedAccounts in following block
+        for (AccountStorageReportResult result : undersubscribedAccounts) {
+            appendResultToBody(result, body);
+        }
+
+        LOGGER.info("sending notification...");
+
+        // send email
+        notification.sendEmail(subject, body.toString());
+
+        LOGGER.info("Report complete: {} oversubscribed,  {} undersubscribedAccounts.",
+                    oversubscribedAccounts.size(),
+                    undersubscribedAccounts.size());
+
+        return new StorageReportResult(oversubscribedAccounts,
+                                       undersubscribedAccounts);
+    }
+
+    /**
+     * @param result
+     * @param body
+     */
+    private void appendResultToBody(AccountStorageReportResult result,
+                                    StringBuilder body) {
+        AccountInfo account = result.getAccount();
+        body.append(MessageFormat.format("{0} (subdomain={1}):\n",
+                                         account.getAcctName(),
+                                         account.getSubdomain()));
+        for (StorageProviderResult presult : result
+                .getStorageProviderResults()) {
+            StorageProviderAccount spa = presult.getStorageProviderAccount();
+            int limit = spa.getStorageLimit();
+            String total = new BigDecimal(presult.getTotalBytes())
+                    .divide(new BigDecimal(StorageProviderResult.TB),
+                            2,
+                            BigDecimal.ROUND_HALF_UP)
+                    .setScale(2, BigDecimal.ROUND_HALF_UP).toString();
+            String capacity = new BigDecimal(presult.getTotalBytes())
+                    .divide(new BigDecimal(limit * StorageProviderResult.TB),
+                            2,
+                            BigDecimal.ROUND_HALF_UP)
+                    .multiply(new BigDecimal(100))
+                    .setScale(2, BigDecimal.ROUND_HALF_UP).toString();
+
+            String line = MessageFormat.format(
+                                               "    provider={0}/{1}, current total: {2} TB, allocated storage: {3} TB, capacity: {4} %, status: {5}\n",
+                                               spa.getId() + "",
+                                               spa.getProviderType().name(),
+                                               total,
+                                               limit,
+                                               capacity,
+                                               presult.isOversubscribed()
+                                                       ? "OVERSUBSCRIBED"
+                                                       : "OK");
+            body.append(line);
+
+        }
+    }
+}

--- a/storage-reporter/src/main/resources/logback.xml
+++ b/storage-reporter/src/main/resources/logback.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration debug="false" scan="false">
+  <jmxConfigurator/>
+  <property name="LOG_FILENAME" value="${duracloud.home}/logs/duracloud-mill-loopingtaskproducer.log" />
+
+  <appender name="DURACLOUD" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <!--See also http://logback.qos.ch/manual/appenders.html#RollingFileAppender-->
+    <File>${LOG_FILENAME}</File>
+
+    <encoder>
+     <pattern>%-6p %d{yyyy/MM/dd HH:mm:ss} [%t] \(%F:%L\) [%M\(\)] - %m%n</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+      <maxIndex>5</maxIndex>
+      <FileNamePattern>${LOG_FILENAME}.%i</FileNamePattern>
+    </rollingPolicy>
+    <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+      <MaxFileSize>20MB</MaxFileSize>
+    </triggeringPolicy>
+  </appender>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+     <pattern>%-6p %d{yyyy/MM/dd HH:mm:ss} [%t] \(%F:%L\) [%M\(\)] - %m%n</pattern>
+    </encoder>
+  </appender>
+  <logger name="org.duracloud.mill" level="${log.level}">
+    <appender-ref ref="DURACLOUD"/>
+  </logger>
+  <root level="WARN">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/storage-reporter/src/test/java/org/duracloud/mill/storagereporter/StorageReporterTest.java
+++ b/storage-reporter/src/test/java/org/duracloud/mill/storagereporter/StorageReporterTest.java
@@ -1,0 +1,143 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.mill.storagereporter;
+
+import static org.junit.Assert.*;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.duracloud.account.db.model.AccountInfo;
+import org.duracloud.account.db.model.AccountInfo.AccountStatus;
+import org.duracloud.account.db.model.StorageProviderAccount;
+import org.duracloud.account.db.repo.DuracloudAccountRepo;
+import org.duracloud.mill.db.repo.JpaSpaceStatsRepo;
+import org.duracloud.mill.notification.NotificationManager;
+import org.duracloud.storage.domain.StorageProviderType;
+import org.easymock.EasyMockRunner;
+import org.easymock.EasyMockSupport;
+import org.easymock.Mock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.easymock.EasyMock.*;
+
+/**
+ * @author dbernstein
+ * @since: Jun 29, 2017
+ */
+@RunWith(EasyMockRunner.class)
+public class StorageReporterTest extends EasyMockSupport {
+
+    @Mock
+    private JpaSpaceStatsRepo statsRepo;
+
+    @Mock
+    private DuracloudAccountRepo accountRepo;
+
+    @Mock
+    private NotificationManager notification;
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setUp() throws Exception {
+
+    }
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @After
+    public void tearDown() throws Exception {
+        verifyAll();
+    }
+
+    @Test
+    public void test() throws Exception {
+        String accountId = "test";
+        Long primaryId = 1l;
+        Long secondaryId = 2l;
+
+        AccountInfo account = createMock(AccountInfo.class);
+        expect(account.getAcctName()).andReturn("Account Name").atLeastOnce();
+        StorageProviderAccount primary = createMock(StorageProviderAccount.class);
+        expect(primary.getId()).andReturn(primaryId).atLeastOnce();
+        expect(primary.getStorageLimit()).andReturn(2).atLeastOnce();
+        expect(primary.getProviderType())
+                .andReturn(StorageProviderType.AMAZON_S3).atLeastOnce();
+
+        StorageProviderAccount secondary = createMock(StorageProviderAccount.class);
+        expect(secondary.getId()).andReturn(secondaryId).atLeastOnce();
+        expect(secondary.getStorageLimit()).andReturn(2).atLeastOnce();
+        expect(secondary.getProviderType())
+                .andReturn(StorageProviderType.AMAZON_GLACIER).atLeastOnce();
+
+        expect(account.getSubdomain()).andReturn(accountId).atLeastOnce();
+        expect(account.getPrimaryStorageProviderAccount()).andReturn(primary);
+        expect(account.getSecondaryStorageProviderAccounts())
+                .andReturn(new HashSet<StorageProviderAccount>(Arrays
+                        .asList(secondary)));
+
+        expect(accountRepo.findByStatus(AccountStatus.ACTIVE))
+                .andReturn(Arrays.asList(account));
+
+        List<Object[]> primaryStats = new LinkedList<>();
+        primaryStats.add(new Object[] { null, null, null,
+                new BigDecimal(StorageProviderResult.TB * 2 + 1) });
+        List<Object[]> secondaryStats = new LinkedList<>();
+        secondaryStats.add(new Object[] { null, null, null,
+                new BigDecimal(StorageProviderResult.TB * 2 - 1) });
+
+        expect(statsRepo
+                .getByAccountIdAndStoreId(eq(accountId),
+                                          eq(primaryId + ""),
+                                          isA(Date.class),
+                                          isA(Date.class),
+                                          eq(JpaSpaceStatsRepo.INTERVAL_DAY)))
+                                                  .andReturn(primaryStats);
+        expect(statsRepo
+                .getByAccountIdAndStoreId(eq(accountId),
+                                          eq(secondaryId + ""),
+                                          isA(Date.class),
+                                          isA(Date.class),
+                                          eq(JpaSpaceStatsRepo.INTERVAL_DAY)))
+                                                  .andReturn(secondaryStats);
+
+        notification.sendEmail(isA(String.class), isA(String.class));
+        expectLastCall();
+
+        replayAll();
+        StorageReporter reporter = new StorageReporter(statsRepo,
+                                                       accountRepo,
+                                                       notification);
+        StorageReportResult result = reporter.run();
+
+        assertEquals(1, result.getOversubscribedAccounts().size());
+        assertEquals(0, result.getUndersubscribedAccounts().size());
+        List<StorageProviderResult> spResults = result
+                .getOversubscribedAccounts().get(0).getStorageProviderResults();
+        for (StorageProviderResult spResult : spResults) {
+            if (spResult.getStorageProviderAccount().getId()
+                    .equals(primaryId)) {
+                assertTrue(spResult.isOversubscribed());
+            } else {
+                assertFalse(spResult.isOversubscribed());
+            }
+        }
+    }
+
+}

--- a/workman/src/main/java/org/duracloud/mill/workman/spring/AppDriver.java
+++ b/workman/src/main/java/org/duracloud/mill/workman/spring/AppDriver.java
@@ -85,7 +85,7 @@ public class AppDriver extends DriverSupport {
                                                                             .addBitIntegrityQueue()
                                                                             .addBitIntegrityErrorQueue()
                                                                             .addBitIntegrityReportQueue()
-                                                                            .addNotificationRecipients()
+                                                                            .addNotifications()
                                                                             .addWorkDir()
                                                                             .addTaskQueueOrder()
                                                                             .addDuplicationPolicyBucketSuffix()


### PR DESCRIPTION
Adds "notification.sender" property to allow for configuring
notification sender email addresses.
Resolves: https://jira.duraspace.org/browse/DURACLOUD-1120

Creates storage report tool to alert duracloud admins when an account
has exceeded its storage limit.

Also adds notification.recipients.non-tech property to configuration for sending to non-technical addresses.
Resolves : https://jira.duraspace.org/browse/DURACLOUD-1070