### PR TITLE
Automates duplication of new spaces.

### DIFF
--- a/common-dup/src/main/java/org/duracloud/mill/dup/DuplicationPolicy.java
+++ b/common-dup/src/main/java/org/duracloud/mill/dup/DuplicationPolicy.java
@@ -7,15 +7,17 @@
  */
 package org.duracloud.mill.dup;
 
-import org.codehaus.jackson.annotate.JsonIgnore;
-import org.codehaus.jackson.map.ObjectMapper;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.codehaus.jackson.map.ObjectMapper;
 
 /**
  * A set of data showing, for a single DuraCloud account, which spaces
@@ -35,6 +37,20 @@ public class DuplicationPolicy {
     private Map<String, LinkedHashSet<DuplicationStorePolicy>>
         spaceDuplicationStorePolicies = new HashMap<>();
 
+    private LinkedHashSet<DuplicationStorePolicy> defaultPolicies = new LinkedHashSet<>();
+    
+
+    private List<String> spacesToIgnore = new LinkedList<>();
+
+    public LinkedHashSet<DuplicationStorePolicy> getDefaultPolicies() {
+        return defaultPolicies;
+    }
+
+
+    public List<String> getSpacesToIgnore() {
+        return spacesToIgnore;
+    }
+
     public Map<String, LinkedHashSet<DuplicationStorePolicy>>
     getSpaceDuplicationStorePolicies() {
         return spaceDuplicationStorePolicies;
@@ -46,7 +62,11 @@ public class DuplicationPolicy {
     }
 
     public Set<DuplicationStorePolicy> getDuplicationStorePolicies(String spaceId) {
-        return spaceDuplicationStorePolicies.get(spaceId);
+        if(!spacesToIgnore.contains(spaceId)){
+            LinkedHashSet<DuplicationStorePolicy> policies = spaceDuplicationStorePolicies.get(spaceId);
+            return policies != null && !policies.isEmpty() ? policies : defaultPolicies;
+        }
+        return null;
     }
 
     /**

--- a/common-dup/src/main/java/org/duracloud/mill/dup/DuplicationPolicy.java
+++ b/common-dup/src/main/java/org/duracloud/mill/dup/DuplicationPolicy.java
@@ -39,14 +39,20 @@ public class DuplicationPolicy {
 
     private LinkedHashSet<DuplicationStorePolicy> defaultPolicies = new LinkedHashSet<>();
     
-
     private List<String> spacesToIgnore = new LinkedList<>();
 
+    /**
+     * A set of default policies.
+     * @return
+     */
     public LinkedHashSet<DuplicationStorePolicy> getDefaultPolicies() {
         return defaultPolicies;
     }
 
-
+    /**
+     * A list of spaces that should be ignored by the duplication task generator.
+     * @return
+     */
     public List<String> getSpacesToIgnore() {
         return spacesToIgnore;
     }
@@ -56,11 +62,21 @@ public class DuplicationPolicy {
         return spaceDuplicationStorePolicies;
     }
 
+    /**
+     * A set of spaces which have policies associated with them.
+     * @return
+     */
     @JsonIgnore
     public Set<String> getSpaces() {
         return spaceDuplicationStorePolicies.keySet();
     }
 
+    /**
+     * Retrieve the duplication store policies associated with a space.   If no policies are set
+     * explicitly for that space, the method returns the default store policies.
+     * @param spaceId
+     * @return
+     */
     public Set<DuplicationStorePolicy> getDuplicationStorePolicies(String spaceId) {
         if(!spacesToIgnore.contains(spaceId)){
             LinkedHashSet<DuplicationStorePolicy> policies = spaceDuplicationStorePolicies.get(spaceId);
@@ -88,11 +104,23 @@ public class DuplicationPolicy {
         return dupStores.add(dupStore);
     }
 
+    /**
+     * Marshals a json stream into a duplication policy object.
+     * @param policyStream
+     * @return
+     * @throws IOException
+     */
     public static DuplicationPolicy unmarshall(InputStream policyStream)
         throws IOException {
         return objMapper.readValue(policyStream, DuplicationPolicy.class);
     }
 
+    /**
+     * Unmarshals a duplication policy into a json string.
+     * @param duplicationPolicy
+     * @return
+     * @throws IOException
+     */
     public static String marshall(DuplicationPolicy duplicationPolicy)
             throws IOException {
         return objMapper.writeValueAsString(duplicationPolicy);

--- a/common-dup/src/main/java/org/duracloud/mill/dup/DuplicationPolicyManager.java
+++ b/common-dup/src/main/java/org/duracloud/mill/dup/DuplicationPolicyManager.java
@@ -33,9 +33,6 @@ public class DuplicationPolicyManager {
         this.policyRepo = policyRepo;
     }
 
-    /**
-     * @param policyRepo
-     */
     private void refreshPolicies() {
         dupAccounts = new HashMap<>();
 

--- a/common-dup/src/test/java/org/duracloud/mill/dup/DuplicationPolicyTest.java
+++ b/common-dup/src/test/java/org/duracloud/mill/dup/DuplicationPolicyTest.java
@@ -10,7 +10,9 @@ package org.duracloud.mill.dup;
 import org.junit.Test;
 
 import java.io.FileInputStream;
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static org.hamcrest.core.Is.is;
@@ -36,6 +38,8 @@ public class DuplicationPolicyTest extends BaseDuplicationPolicyTester {
         storePolicy13.setDestStoreId("3");
 
         DuplicationPolicy duplicationPolicy = new DuplicationPolicy();
+        duplicationPolicy.getSpacesToIgnore().add("testIgnore");
+        duplicationPolicy.getDefaultPolicies().add(new DuplicationStorePolicy("defaultSource", "defaultDest"));
         duplicationPolicy.addDuplicationStorePolicy("testSpace1", storePolicy12);
         duplicationPolicy.addDuplicationStorePolicy("testSpace1", storePolicy13);
         duplicationPolicy.addDuplicationStorePolicy("testSpace2", storePolicy12);
@@ -61,6 +65,9 @@ public class DuplicationPolicyTest extends BaseDuplicationPolicyTester {
         assertThat(2, is(equalTo(space1DuplicationStorePolicies.size())));
         assertThat(1, is(equalTo(space2DuplicationStorePolicies.size())));
 
+        assertThat(1, is(equalTo(duplicationPolicy.getDefaultPolicies().size())));
+        assertThat(1, is(equalTo(duplicationPolicy.getSpacesToIgnore().size())));
+
         Iterator<DuplicationStorePolicy> space1Iter = space1DuplicationStorePolicies.iterator();
         DuplicationStorePolicy duplicationStorePolicy = space1Iter.next();
         assertThat("1", is(equalTo(duplicationStorePolicy.getSrcStoreId())));
@@ -75,5 +82,16 @@ public class DuplicationPolicyTest extends BaseDuplicationPolicyTester {
         assertThat("1", is(equalTo(duplicationStorePolicy.getSrcStoreId())));
         assertThat("2", is(equalTo(duplicationStorePolicy.getDestStoreId())));
         assertFalse(space2Iter.hasNext());
+    }
+    
+    @Test
+    public void testDuplicationPolicyDefaults() throws Exception {
+        DuplicationPolicy duplicationPolicy =
+            DuplicationPolicy.unmarshall(new FileInputStream(policyFile));
+        String spaceToIgnore = duplicationPolicy.getSpacesToIgnore().get(0);
+        String spaceNotToIgnore = "spaceNotToIgnore";
+        Set<DuplicationStorePolicy> defaultPolicies = duplicationPolicy.getDefaultPolicies();
+        assertThat(defaultPolicies, is(equalTo(duplicationPolicy.getDuplicationStorePolicies(spaceNotToIgnore))));
+        assertThat(duplicationPolicy.getDuplicationStorePolicies(spaceToIgnore), is(equalTo(null)));
     }
 }

--- a/common-dup/src/test/resources/duplication-policy.json
+++ b/common-dup/src/test/resources/duplication-policy.json
@@ -1,4 +1,13 @@
 {
+    "defaultPolicies": [
+    	{
+                "srcStoreId":"defaultSrc",
+                "destStoreId":"defaultDest"
+        }
+    ],
+    "spacesToIgnore": [
+    	"ignoredSpace"
+    ],
     "spaceDuplicationStorePolicies": {
         "testSpace1": [
             {

--- a/loopingduptaskproducer/src/main/java/org/duracloud/mill/ltp/dup/LoopingDuplicationTaskProducer.java
+++ b/loopingduptaskproducer/src/main/java/org/duracloud/mill/ltp/dup/LoopingDuplicationTaskProducer.java
@@ -84,7 +84,6 @@ public class LoopingDuplicationTaskProducer extends LoopingTaskProducer<Duplicat
         return cache;
     }
     
-
     /* (non-Javadoc)
      * @see org.duracloud.mill.ltp.LoopingTaskProducer#loadMorselQueueFromSource(java.util.Queue)
      */

--- a/loopingduptaskproducer/src/main/java/org/duracloud/mill/ltp/dup/LoopingDuplicationTaskProducer.java
+++ b/loopingduptaskproducer/src/main/java/org/duracloud/mill/ltp/dup/LoopingDuplicationTaskProducer.java
@@ -94,29 +94,29 @@ public class LoopingDuplicationTaskProducer extends LoopingTaskProducer<Duplicat
         for(String account : this.policyManager.getDuplicationAccounts()){
             DuplicationPolicy policy = this.policyManager.getDuplicationPolicy(account);
             try {
-                AccountCredentials accountCreds = getCredentialsRepo().getAccountCredentials(account);
-                for(StorageProviderCredentials cred: accountCreds.getProviderCredentials()){
-                    if(cred.isPrimary()){
-                        StorageProvider provider = getStorageProvider(account, cred.getProviderId());
-                        Iterator<String> spaces = provider.getSpaces();
-                        while(spaces.hasNext()){
-                            String spaceId = spaces.next();
-                            Set<DuplicationStorePolicy> storePolicies = policy.getDuplicationStorePolicies(spaceId);
-                            for(DuplicationStorePolicy storePolicy : storePolicies){
-                                morselQueue.add(new DuplicationMorsel(account, spaceId, null, storePolicy));
+                final CredentialsRepo credRepo = getCredentialsRepo();
+                if(getCredentialsRepo().isAccountActive(account)) {
+                    AccountCredentials accountCreds = credRepo.getAccountCredentials(account);
+                    for (StorageProviderCredentials cred : accountCreds.getProviderCredentials()) {
+                        if (cred.isPrimary()) {
+                            StorageProvider provider = getStorageProvider(cred);
+                            Iterator<String> spaces = provider.getSpaces();
+                            while (spaces.hasNext()) {
+                                String spaceId = spaces.next();
+                                Set<DuplicationStorePolicy> storePolicies = policy.getDuplicationStorePolicies(spaceId);
+                                for (DuplicationStorePolicy storePolicy : storePolicies) {
+                                    morselQueue.add(new DuplicationMorsel(account, spaceId, null, storePolicy));
+                                }
                             }
                         }
                     }
                 }
-            
             } catch (AccountCredentialsNotFoundException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
-
         }
     }
-    
+
     /* (non-Javadoc)
      * @see org.duracloud.mill.ltp.LoopingTaskProducer#nibble(org.duracloud.mill.ltp.Queue<T>)
      */
@@ -168,7 +168,12 @@ public class LoopingDuplicationTaskProducer extends LoopingTaskProducer<Duplicat
             
         }   
     }
-    
+
+    @Override
+    protected StorageProvider getStorageProvider(String account, String storeId) {
+        return super.getStorageProvider(account, storeId);
+    }
+
     /**
      * 
      * @param morsel

--- a/policy-editor/src/main/webapp/index.html
+++ b/policy-editor/src/main/webapp/index.html
@@ -71,8 +71,6 @@
 	</p>
   </div>
 </div>
-	
-	
 </script>
 
 <script type="text/x-handlebars" data-template-name="accounts.index">
@@ -80,7 +78,7 @@
 </script>
 
 <script type="text/x-handlebars" data-template-name="accounts">
-       <div class="col-md-3">
+       <div class="col-md-2">
          <div class="form-group"> 
 		<span data-toggle='tooltip' title='To set up an account, enter a valid account subdomain.' data-placement='right'>
            {{input class="form-control"  
@@ -110,7 +108,18 @@
 </script>
 
 <script type="text/x-handlebars" data-template-name="policy">
-      <div class="col-md-3">
+   <div class="col-md-5">
+       <div class="row">
+         <div class="col-xs-12 form-group">
+            <label class="control-label">{{id}}'s Default Policies</label> 
+	     </div>
+       </div>
+	   <div class="row">
+         <div class="col-xs-12 form-group">
+
+		   {{partial "policyEditor"}}
+		 </div>
+       </div>
        <div class="row">
          <div class="col-xs-12 form-group">
             <label class="control-label" style="padding-top:6px">{{id}}'s Configs </label> 
@@ -145,7 +154,21 @@
 </script>
 
 <script type="text/x-handlebars" data-template-name="space">
-      <div class="col-md-6">
+   <div class="col-md-5">
+		<h3>{{model.spaceId}}'s policies</h3>
+   </div>
+
+   <div class="col-md-5">
+       <label>
+        {{input type='checkbox' checked=model.ignored}} Do not duplicate this space
+       </label>
+   </div>
+   <div class="col-md-5">
+   {{partial "policyEditor"}}
+   </div>
+</script>
+
+<script type="text/x-handlebars" data-template-name="_policyEditor">
      <table class="table">
        <thead>
          <tr>
@@ -198,9 +221,8 @@
           {{/each}}
        </tbody>
      </table>
-     </div>
-  
 </script>
+
 
 <script type="text/x-handlebars" data-template-name="header">
 <nav class="navbar navbar-default navbar-fixed-top" role="navigation">

--- a/policy-editor/src/main/webapp/js/controllers/store_policy_controller.js
+++ b/policy-editor/src/main/webapp/js/controllers/store_policy_controller.js
@@ -17,8 +17,71 @@ App.SpaceController = Ember.ObjectController.extend({
    						  // policy controller via the get() method.
     storageProviders: function(){
       return this.get('controllers.policy').get('model.storageProviders');
-    }.property('model.storageProviders')
+    }.property('model.storageProviders'),
   
+    spaceId: function(){
+        return this.get('controllers.policy').get('model.spaceId');
+    }.property('model.spaceId'),
+
+    watchIgnored: function(){
+		console.debug("ignored changed! value=" + this.get("model.ignored"));
+		this.save();
+
+    }.observes('model.ignored'),
+
+    save: function(){
+        this.get('controllers.policy').get('model').save(function(){
+            alert("saved policy!");
+        }, function(){
+            alert('failed to save policy');
+        });
+    },
+
+    actions: {
+ 	   deleteStorePolicy: function(storePolicy){
+		   this.get("model").get('storePolicies').removeObject(storePolicy);
+		   storePolicy.deleteRecord();
+
+		   
+		   this.get('controllers.policy').get('model').save(null, function(){
+			   alert('failed to delete policy');
+		   });
+	   },
+
+  	   addStorePolicy: function(srcStore,destStore){
+		   var that = this;
+		   console.log("addStore clicked: srcStoreId=" + srcStore.id + ", destStoreId="+destStore.id);
+
+		   if(srcStore.id == destStore.id){
+			   alert("The source and destination cannot be identical.");
+			   return;
+		   }
+		   
+		   var storePolicies = that.get('model').get('storePolicies');
+
+		   //check for duplications
+		   var duplicate = false;
+		   storePolicies.forEach(function(element){
+			   if(element.srcStoreId == srcStore.id && element.destStoreId == destStore.id){
+				   duplicate = true;
+			   }
+		   });
+		   
+		   if(duplicate){
+			   alert("A policy for the specified source and destination already exists.");
+			   return;
+		   }
+
+		   var record = this.store.push('storePolicy', {
+				id : App.generateUUID(),
+				source: srcStore,
+				destination: destStore,
+			});
+		   
+		   storePolicies.pushObject(record);
+		   this.save();
+	   },
+     }
 });
 
 

--- a/policy-editor/src/main/webapp/js/data_model.js
+++ b/policy-editor/src/main/webapp/js/data_model.js
@@ -9,14 +9,18 @@ App.StorePolicy = DS.Model.extend({
 
 App.Space = DS.Model.extend({
 	spaceId: DS.attr(),
+	ignored: DS.attr(),
 	storePolicies: DS.hasMany(App.StorePolicy),
 });
 
 
 App.Policy = DS.Model.extend({
 	spaces: DS.hasMany(App.Space),
-	storageProviders: DS.hasMany(App.StorageProviders)
+	storageProviders: DS.hasMany(App.StorageProviders),
+	defaultPolicies: DS.hasMany(App.StorePolicy)
 });
+
+
 
 App.Account = DS.Model.extend({
 	

--- a/policy-editor/src/main/webapp/js/router.js
+++ b/policy-editor/src/main/webapp/js/router.js
@@ -61,7 +61,7 @@ App.LoadingRoute = Ember.Route.extend({
 		this._super();
 		var flickerAPI = "http://api.flickr.com/services/feeds/photos_public.gne?jsoncallback=?";
 		  $.getJSON( flickerAPI, {
-		    tags: "twins",
+		    tags: "clouds",
 		    tagmode: "any",
 		    format: "json"
 		  }).done(function( data ) {
@@ -169,6 +169,11 @@ App.StorePolicyView = App.FadingView.extend({
 });
 
 App.SpaceRoute = BaseRoute.extend({
+
+  setupController: function(controller,model){
+      controller.set('model', model);
+  },
+
   model: function(params) {
 	  var spaces = this.modelFor('policy').get('spaces');
 	  var space = null;
@@ -183,7 +188,6 @@ App.SpaceRoute = BaseRoute.extend({
       return space;
   },
   
-
   renderTemplate: function(){
 		this.render({outlet:'right'});  
   },
@@ -196,53 +200,6 @@ App.SpaceRoute = BaseRoute.extend({
   
   actions: {
 	  
-	   deleteStorePolicy: function(storePolicy){
-		   this.modelFor('space').get('storePolicies').removeObject(storePolicy);
-		   storePolicy.deleteRecord();
-
-		   this.modelFor('policy').save(null, function(){
-			   alert('failed to delete policy');
-		   });
-	   },
-	   
-	   addStorePolicy: function(srcStore,destStore){
-		   var that = this;
-		   console.log("addStore clicked: srcStoreId=" + srcStore.id + ", destStoreId="+destStore.id);
-
-		   if(srcStore.id == destStore.id){
-			   alert("The source and destination cannot be identical.");
-			   return;
-		   }
-		   
-		   var storePolicies = this.modelFor('space').get('storePolicies');
-
-		   //check for duplications
-		   var duplicate = false;
-		   storePolicies.forEach(function(element){
-			   if(element.srcStoreId == srcStore.id && element.destStoreId == destStore.id){
-				   duplicate = true;
-			   }
-		   });
-		   
-		   if(duplicate){
-			   alert("A policy for the specified source and destination already exists.");
-			   return;
-		   }
-
-		   var record = this.store.push('storePolicy', {
-				id : App.generateUUID(),
-				source: srcStore,
-				destination: destStore,
-			});
-		   
-		   storePolicies.pushObject(record);
-		   var policy = this.modelFor('policy');
-		   policy.save(function(){
-			   console.log('saved ' + record  +' into ' + policy.id)
-		   }, function(text){ 
-			   alert("failed to save store policy :" + text);
-		   });
-	   }
   },
   
 });

--- a/policy-editor/src/test/resources/duplication-policy.json
+++ b/policy-editor/src/test/resources/duplication-policy.json
@@ -1,4 +1,13 @@
 {
+    "defaultPolicies": [
+    	{
+                "srcStoreId":"defaultSrc",
+                "destStoreId":"defaultDest"
+        }
+    ],
+    "spacesToIgnore": [
+    	"ignoredSpace"
+    ],
     "spaceDuplicationStorePolicies": {
         "testSpace1": [
             {


### PR DESCRIPTION
This update adds some new properties to the duplication policies that allow
the user to set a default duplication policy for the account. Duplication
policies for spaces will override the defaults. Also the user has the option
to prevent duplication of a space.
Resolves:  https://jira.duraspace.org/browse/DURACLOUD-979