### PR TITLE
Spaces with prefixed by  "x-" are now automatically ignored.

### DIFF
--- a/common-dup/src/main/java/org/duracloud/mill/dup/DuplicationPolicy.java
+++ b/common-dup/src/main/java/org/duracloud/mill/dup/DuplicationPolicy.java
@@ -81,7 +81,7 @@ public class DuplicationPolicy {
      * @return
      */
     public Set<DuplicationStorePolicy> getDuplicationStorePolicies(String spaceId) {
-        if (!spacesToIgnore.contains(spaceId)) {
+        if (!spaceId.startsWith("x-") && !spacesToIgnore.contains(spaceId)) {
             LinkedHashSet<DuplicationStorePolicy> policies = spaceDuplicationStorePolicies.get(spaceId);
             return policies != null && !policies.isEmpty() ? policies : defaultPolicies;
         }

--- a/common-dup/src/test/java/org/duracloud/mill/dup/DuplicationPolicyTest.java
+++ b/common-dup/src/test/java/org/duracloud/mill/dup/DuplicationPolicyTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
  */
 public class DuplicationPolicyTest extends BaseDuplicationPolicyTester {
 
-    //@Test
+    @Test
     public void testDuplicationPolicyMarshall() throws Exception {
         DuplicationStorePolicy storePolicy12 = new DuplicationStorePolicy();
         storePolicy12.setSrcStoreId("1");
@@ -92,4 +92,12 @@ public class DuplicationPolicyTest extends BaseDuplicationPolicyTester {
         assertThat(defaultPolicies, is(equalTo(duplicationPolicy.getDuplicationStorePolicies(spaceNotToIgnore))));
         assertThat(duplicationPolicy.getDuplicationStorePolicies(spaceToIgnore), is(equalTo(null)));
     }
+
+    @Test
+    public void testIgnoreXPrefixedSpaces() throws Exception {
+        DuplicationPolicy duplicationPolicy =
+            DuplicationPolicy.unmarshall(new FileInputStream(policyFile));
+        assertThat(duplicationPolicy.getDuplicationStorePolicies("x-space"), is(equalTo(null)));
+    }
+
 }


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/DURACLOUD-1170

Unit tests cover the changes to the code. 
For full integration test, simply ensure that a default duplication policy is configured for the account, add a space prefixed by "x-" and add a content item to it.  Verify that the content was not duplicated.