### PR TITLE
DURACLOUD-1214: Removes references to DPN

### DIFF
--- a/common-storageprovider/src/main/java/org/duracloud/mill/common/storageprovider/StorageProviderFactory.java
+++ b/common-storageprovider/src/main/java/org/duracloud/mill/common/storageprovider/StorageProviderFactory.java
@@ -15,7 +15,6 @@ import org.duracloud.mill.credentials.StorageProviderCredentials;
 import org.duracloud.mill.util.SimpleUserUtil;
 import org.duracloud.s3storage.S3StorageProvider;
 import org.duracloud.snapshotstorage.ChronopolisStorageProvider;
-import org.duracloud.snapshotstorage.DpnStorageProvider;
 import org.duracloud.storage.domain.StorageProviderType;
 import org.duracloud.storage.provider.StorageProvider;
 
@@ -69,9 +68,6 @@ public class StorageProviderFactory {
             return new GlacierStorageProvider(credentials.getAccessKey(),
                                               credentials.getSecretKey(),
                                               credentials.getOptions());
-        } else if (storageProviderType.equals(StorageProviderType.DPN)) {
-            return new DpnStorageProvider(credentials.getAccessKey(),
-                                          credentials.getSecretKey());
         } else if (storageProviderType.equals(StorageProviderType.CHRONOPOLIS)) {
             return new ChronopolisStorageProvider(credentials.getAccessKey(),
                                                   credentials.getSecretKey());

--- a/pom.xml
+++ b/pom.xml
@@ -337,6 +337,9 @@
         <configuration>
           <skipTests>${skipUTs}</skipTests>
           <trimStackTrace>false</trimStackTrace>
+          <environmentVariables>
+            <AWS_REGION>us-east-1</AWS_REGION>
+          </environmentVariables>
           <systemProperties>
             <property>
               <name>PROJECT_VERSION</name>

--- a/pom.xml
+++ b/pom.xml
@@ -172,8 +172,8 @@
     <log.level.default>INFO</log.level.default>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <duracloud.version>4.4.6</duracloud.version>
-    <duracloud.db.version>4.1.1</duracloud.db.version>
+    <duracloud.version>5.2.0-SNAPSHOT</duracloud.version>
+    <duracloud.db.version>5.2.0-SNAPSHOT</duracloud.db.version>
     <aws.sdk.version>1.11.155</aws.sdk.version>
     <spring.framework.version>4.2.5.RELEASE</spring.framework.version>
     <powermock.version>1.5.4</powermock.version>

--- a/workman/src/main/java/org/duracloud/mill/bit/ContentChecksumHelper.java
+++ b/workman/src/main/java/org/duracloud/mill/bit/ContentChecksumHelper.java
@@ -68,7 +68,7 @@ public class ContentChecksumHelper {
                 @Override
                 public String retry() throws Exception {
                     try (InputStream inputStream =
-                             store.getContent(bitTask.getSpaceId(), bitTask.getContentId())) {
+                             store.getContent(bitTask.getSpaceId(), bitTask.getContentId()).getContentStream()) {
                         String checksum = checksumUtil.generateChecksum(inputStream);
 
                         contentChecksum = checksum;

--- a/workman/src/main/java/org/duracloud/mill/dup/DuplicationTaskProcessor.java
+++ b/workman/src/main/java/org/duracloud/mill/dup/DuplicationTaskProcessor.java
@@ -441,7 +441,7 @@ public class DuplicationTaskProcessor extends TaskProcessorBase {
                 @Override
                 public InputStream retry() throws Exception {
                     // Retrieve from source
-                    return sourceStore.getContent(spaceId, contentId);
+                    return sourceStore.getContent(spaceId, contentId).getContentStream();
                 }
             });
         } catch (Exception e) {

--- a/workman/src/main/java/org/duracloud/mill/storagestats/StorageStatsTaskProcessor.java
+++ b/workman/src/main/java/org/duracloud/mill/storagestats/StorageStatsTaskProcessor.java
@@ -95,7 +95,6 @@ public class StorageStatsTaskProcessor extends TaskProcessorBase {
 
         String spaceId = this.storageStatsTask.getSpaceId();
         if (storageProviderType.equals(StorageProviderType.AMAZON_S3) ||
-            storageProviderType.equals(StorageProviderType.DPN) ||
             storageProviderType.equals(StorageProviderType.CHRONOPOLIS)) {
 
             BucketStats stats = this.storageStatsGatherer.getBucketStats(spaceId);

--- a/workman/src/test/java/org/duracloud/mill/bit/BitIntegrityCheckTaskProcessorTest.java
+++ b/workman/src/test/java/org/duracloud/mill/bit/BitIntegrityCheckTaskProcessorTest.java
@@ -32,6 +32,7 @@ import org.duracloud.mill.manifest.ManifestItemWriteException;
 import org.duracloud.mill.manifest.ManifestStore;
 import org.duracloud.mill.workman.TaskExecutionFailedException;
 import org.duracloud.mill.workman.TaskWorker;
+import org.duracloud.storage.domain.RetrievedContent;
 import org.duracloud.storage.domain.StorageProviderType;
 import org.duracloud.storage.error.NotFoundException;
 import org.duracloud.storage.provider.StorageProvider;
@@ -203,7 +204,9 @@ public class BitIntegrityCheckTaskProcessorTest extends EasyMockSupport {
      */
     private InputStream storeMockInputstream() {
         InputStream is = EasyMock.createMock(InputStream.class);
-        EasyMock.expect(store.getContent(spaceId, contentId)).andReturn(is);
+        RetrievedContent retrievedContent = new RetrievedContent();
+        retrievedContent.setContentStream(is);
+        EasyMock.expect(store.getContent(spaceId, contentId)).andReturn(retrievedContent);
         return is;
     }
 
@@ -232,11 +235,6 @@ public class BitIntegrityCheckTaskProcessorTest extends EasyMockSupport {
     @Test
     public void testSuccessWithOutContentCheckGlacier() throws Exception {
         testSuccess(StorageProviderType.AMAZON_GLACIER, false);
-    }
-
-    @Test
-    public void testSuccessWithOutContentCheckDpn() throws Exception {
-        testSuccess(StorageProviderType.DPN, false);
     }
 
     @Test

--- a/workman/src/test/java/org/duracloud/mill/bit/ContentChecksumHelperTest.java
+++ b/workman/src/test/java/org/duracloud/mill/bit/ContentChecksumHelperTest.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 
 import org.duracloud.common.util.ChecksumUtil;
 import org.duracloud.mill.workman.TaskExecutionFailedException;
+import org.duracloud.storage.domain.RetrievedContent;
 import org.duracloud.storage.domain.StorageProviderType;
 import org.duracloud.storage.provider.StorageProvider;
 import org.easymock.EasyMockRunner;
@@ -111,8 +112,11 @@ public class ContentChecksumHelperTest extends EasyMockSupport {
     private void setupStorageProvider(int times) throws IOException {
         is.close();
         expectLastCall().times(times);
-        expect(store.getContent(eq(spaceId), eq(contentId))).andReturn(is).times(times);
 
+        RetrievedContent retrievedContent = new RetrievedContent();
+        retrievedContent.setContentStream(is);
+        expect(store.getContent(eq(spaceId), eq(contentId)))
+            .andReturn(retrievedContent).times(times);
     }
 
     private void setupTask(int times) {

--- a/workman/src/test/java/org/duracloud/mill/dup/DuplicationTaskProcessorFactoryTest.java
+++ b/workman/src/test/java/org/duracloud/mill/dup/DuplicationTaskProcessorFactoryTest.java
@@ -40,8 +40,6 @@ public class DuplicationTaskProcessorFactoryTest {
                                                               StorageProviderType.AMAZON_GLACIER});
         successfulProviderList.add(new StorageProviderType[] {StorageProviderType.AMAZON_S3,
                                                               StorageProviderType.CHRONOPOLIS});
-        successfulProviderList.add(new StorageProviderType[] {StorageProviderType.AMAZON_S3,
-                                                              StorageProviderType.DPN});
 
         //successes
         for (StorageProviderType[] a : successfulProviderList) {

--- a/workman/src/test/java/org/duracloud/mill/dup/DuplicationTaskProcessorTest.java
+++ b/workman/src/test/java/org/duracloud/mill/dup/DuplicationTaskProcessorTest.java
@@ -24,6 +24,7 @@ import org.duracloud.mill.db.model.ManifestItem;
 import org.duracloud.mill.manifest.ManifestStore;
 import org.duracloud.mill.task.DuplicationTask;
 import org.duracloud.mill.workman.TaskExecutionFailedException;
+import org.duracloud.storage.domain.RetrievedContent;
 import org.duracloud.storage.error.NotFoundException;
 import org.duracloud.storage.error.StorageStateException;
 import org.duracloud.storage.provider.StorageProvider;
@@ -511,9 +512,11 @@ public class DuplicationTaskProcessorTest {
 
         // Get source content
         InputStream contentStream = IOUtil.writeStringToStream(content);
+        RetrievedContent retrievedContent = new RetrievedContent();
+        retrievedContent.setContentStream(contentStream);
         EasyMock.expect(srcStore.getContent(EasyMock.eq(spaceId),
                                             EasyMock.eq(contentId)))
-                .andReturn(contentStream);
+                .andReturn(retrievedContent);
 
         // Add dest content
         EasyMock.expect(destStore.addContent(EasyMock.eq(spaceId),
@@ -569,9 +572,11 @@ public class DuplicationTaskProcessorTest {
 
         // Get source content
         InputStream contentStream = IOUtil.writeStringToStream(content);
+        RetrievedContent retrievedContent = new RetrievedContent();
+        retrievedContent.setContentStream(contentStream);
         EasyMock.expect(srcStore.getContent(EasyMock.eq(spaceId),
                                             EasyMock.eq(contentId)))
-                .andReturn(contentStream);
+                .andReturn(retrievedContent);
 
         // Add dest content
         EasyMock.expect(destStore.addContent(EasyMock.eq(spaceId),

--- a/workman/src/test/java/org/duracloud/mill/storagestats/StorageStatsTaskProcessorTest.java
+++ b/workman/src/test/java/org/duracloud/mill/storagestats/StorageStatsTaskProcessorTest.java
@@ -139,11 +139,6 @@ public class StorageStatsTaskProcessorTest extends EasyMockSupport {
     }
 
     @Test
-    public void testDpn() throws Exception {
-        testS3Based(StorageProviderType.DPN);
-    }
-
-    @Test
     public void testChronopolis() throws Exception {
         testS3Based(StorageProviderType.CHRONOPOLIS);
     }


### PR DESCRIPTION
**JIRA Ticket**: (link)

https://jira.duraspace.org/browse/DURACLOUD-1214

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

[duracloud/duracloud-db#10](https://github.com/duracloud/duracloud-db/pull/10)
[duracloud/duracloud#87](https://github.com/duracloud/duracloud/pull/87)
[duracloud/management-console#22](https://github.com/duracloud/management-console/pull/22)
https://github.com/duracloud/snapshot/pull/14

# What does this Pull Request do?
A in-depth description of the changes made by this PR. Technical details and possible side effects.

Removes references to DPN

Also updates DuraCloud and DuraCloud-DB dependencies to latest, which required change to handling of return type for the StorageProvider.getContent() call (return type changed to RetrievedContent)

# How should this be tested?
With changes in other PRs for DURACLOUD-1214, submit a snapshot and perform a restore