### PR TITLE
Updates to enable building javadocs using java 11.  This update

### DIFF
--- a/common/src/main/java/org/duracloud/mill/util/PropertyFileHelper.java
+++ b/common/src/main/java/org/duracloud/mill/util/PropertyFileHelper.java
@@ -29,8 +29,8 @@ public class PropertyFileHelper {
      * If the resulting system property value does not resolve to an existing file,
      * The system will exit after logging the error.
      *
-     * @param profileFileSystemProperty The system property to check
-     * @param defaultFilePath           The default property file path
+     * @param propertyFileSystemProperty The system property to check
+     * @param defaultPropertyFilePath The default property file path
      */
     public static void loadFromSystemProperty(String propertyFileSystemProperty, String defaultPropertyFilePath) {
         String path = System.getProperty(propertyFileSystemProperty);

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <profile>
       <id>java8-disable-strict-javadoc</id>
       <activation>
-        <jdk>[1.8,)</jdk>
+        <jdk>[1.8,11,)</jdk>
       </activation>
       <properties>
         <javadoc.opts>-Xdoclint:none</javadoc.opts>
@@ -133,6 +133,7 @@
                   <goal>jar</goal>
                 </goals>
                 <configuration>
+                  <source>8</source>
                   <additionalparam>${javadoc.opts}</additionalparam>
                 </configuration>
               </execution>


### PR DESCRIPTION
is required in order to get the deployment to sonatype working again.