### PR TITLE
DURACLOUD-1286: update mysql-connector-java to latest 5.1 bugfix release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
     <powermock.version>1.5.4</powermock.version>
     <spring.framework.data.jpa.version>1.10.1.RELEASE</spring.framework.data.jpa.version>
     <hibernate.version>5.1.0.Final</hibernate.version>
-    <mysql.driver.version>5.1.28</mysql.driver.version>
+    <mysql.driver.version>5.1.49</mysql.driver.version>
     <jackson.version>2.7.4</jackson.version>
     <jaxb.api.version>2.3.1</jaxb.api.version>
     <jaxb.runtime.version>2.3.3</jaxb.runtime.version>


### PR DESCRIPTION
JIRA issue: https://jira.lyrasis.org/browse/DURACLOUD-1286

Includes bug fixes and updates that will improve functionality with more recent versions of MySQL.