### PR TITLE
DURACLOUD-1304

### DIFF
--- a/common-dup/pom.xml
+++ b/common-dup/pom.xml
@@ -17,6 +17,12 @@
   <dependencies>
 
     <dependency>
+      <groupId>org.duracloud.mill</groupId>
+      <artifactId>common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.duracloud</groupId>
       <artifactId>common</artifactId>
     </dependency>

--- a/common-dup/src/main/java/org/duracloud/mill/dup/util/DefaultPolicyGenerator.java
+++ b/common-dup/src/main/java/org/duracloud/mill/dup/util/DefaultPolicyGenerator.java
@@ -19,7 +19,7 @@ import org.duracloud.client.ContentStoreManagerImpl;
 import org.duracloud.common.constant.Constants;
 import org.duracloud.common.model.Credential;
 import org.duracloud.error.ContentStoreException;
-import org.duracloud.mill.config.ConfigConstants;
+import org.duracloud.mill.config.ConfigurationManager;
 import org.duracloud.mill.dup.DuplicationPolicy;
 import org.duracloud.mill.dup.DuplicationStorePolicy;
 import org.duracloud.mill.dup.repo.DuplicationPolicyRepo;
@@ -75,11 +75,8 @@ public class DefaultPolicyGenerator {
                                                    String rootPass)
         throws ContentStoreException {
 
-        String domain = System.getProperty(ConfigConstants.DURACLOUD_SITE_DOMAIN);
-        if (domain == null) {
-            domain = Constants.DEFAULT_DOMAIN;
-        }
-        String host = account + "." + domain;
+        ConfigurationManager configManager = new ConfigurationManager();
+        String host = configManager.getSubdomainDotDefaultDomain(account);
 
         ContentStoreManager storeManager =
             new ContentStoreManagerImpl(host, DURACLOUD_PORT);

--- a/common-dup/src/main/java/org/duracloud/mill/dup/util/DefaultPolicyGenerator.java
+++ b/common-dup/src/main/java/org/duracloud/mill/dup/util/DefaultPolicyGenerator.java
@@ -19,6 +19,7 @@ import org.duracloud.client.ContentStoreManagerImpl;
 import org.duracloud.common.constant.Constants;
 import org.duracloud.common.model.Credential;
 import org.duracloud.error.ContentStoreException;
+import org.duracloud.mill.config.ConfigConstants;
 import org.duracloud.mill.dup.DuplicationPolicy;
 import org.duracloud.mill.dup.DuplicationStorePolicy;
 import org.duracloud.mill.dup.repo.DuplicationPolicyRepo;
@@ -34,7 +35,6 @@ import org.duracloud.mill.dup.repo.DuplicationPolicyRepo;
  */
 public class DefaultPolicyGenerator {
 
-    private static final String DURACLOUD_URL_SUFFIX = ".duracloud.org";
     private static final String DURACLOUD_PORT = "443";
     private static final String DURACLOUD_ROOT_USER = "root";
 
@@ -74,7 +74,13 @@ public class DefaultPolicyGenerator {
     private ContentStoreManager connectToDuraCloud(String account,
                                                    String rootPass)
         throws ContentStoreException {
-        String host = account + DURACLOUD_URL_SUFFIX;
+
+        String domain = System.getProperty(ConfigConstants.DURACLOUD_SITE_DOMAIN);
+        if (domain == null) {
+            domain = Constants.DEFAULT_DOMAIN;
+        }
+        String host = account + "." + domain;
+
         ContentStoreManager storeManager =
             new ContentStoreManagerImpl(host, DURACLOUD_PORT);
         Credential credential = new Credential(DURACLOUD_ROOT_USER, rootPass);

--- a/common/src/main/java/org/duracloud/mill/config/ConfigConstants.java
+++ b/common/src/main/java/org/duracloud/mill/config/ConfigConstants.java
@@ -52,6 +52,8 @@ public class ConfigConstants {
     public static final String NOTIFICATION_USER = "notification.user";
     public static final String NOTIFICATION_PASS = "notification.pass";
 
+    public static final String DURACLOUD_SITE_DOMAIN = "duracloud-site.domain";
+
     /*
      * AUDIT LOG GENERATOR
      */

--- a/common/src/main/java/org/duracloud/mill/config/ConfigurationManager.java
+++ b/common/src/main/java/org/duracloud/mill/config/ConfigurationManager.java
@@ -8,6 +8,7 @@
 package org.duracloud.mill.config;
 
 import org.apache.commons.lang3.StringUtils;
+import org.duracloud.common.constant.Constants;
 import org.duracloud.common.model.EmailerType;
 import org.duracloud.common.queue.QueueType;
 
@@ -105,5 +106,17 @@ public class ConfigurationManager {
 
     public String[] getNotificationRecipientsNonTech() {
         return getCommaSeparatedListToArray(ConfigConstants.NOTIFICATION_RECIPIENTS_NON_TECH);
+    }
+
+    public String getDefaultDomain() {
+        String domain = System.getProperty(ConfigConstants.DURACLOUD_SITE_DOMAIN);
+        if (domain == null) {
+            domain = Constants.DEFAULT_DOMAIN;
+        }
+        return domain;
+    }
+
+    public String getSubdomainDotDefaultDomain(String subdomain) {
+        return subdomain + "." + getDefaultDomain();
     }
 }

--- a/common/src/main/java/org/duracloud/mill/util/PropertyDefinitionListBuilder.java
+++ b/common/src/main/java/org/duracloud/mill/util/PropertyDefinitionListBuilder.java
@@ -129,6 +129,7 @@ public class PropertyDefinitionListBuilder {
         add(ConfigConstants.NOTIFICATION_PORT, false);
         add(ConfigConstants.NOTIFICATION_USER, false);
         add(ConfigConstants.NOTIFICATION_PASS, false, true);
+        add(ConfigConstants.DURACLOUD_SITE_DOMAIN, false);
         return this;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -824,6 +824,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.javassist</groupId>
+        <artifactId>javassist</artifactId>
+        <version>3.24.0-GA</version>
+      </dependency>
+
+      <dependency>
         <groupId>mysql</groupId>
         <artifactId>mysql-connector-java</artifactId>
         <version>${mysql.driver.version}</version>

--- a/workman/src/main/java/org/duracloud/mill/audit/SpaceCreatedNotifcationGeneratingProcessor.java
+++ b/workman/src/main/java/org/duracloud/mill/audit/SpaceCreatedNotifcationGeneratingProcessor.java
@@ -8,8 +8,7 @@
 package org.duracloud.mill.audit;
 
 import org.duracloud.audit.task.AuditTask;
-import org.duracloud.common.constant.Constants;
-import org.duracloud.mill.config.ConfigConstants;
+import org.duracloud.mill.config.ConfigurationManager;
 import org.duracloud.mill.notification.NotificationManager;
 import org.duracloud.mill.workman.TaskExecutionFailedException;
 import org.duracloud.mill.workman.TaskProcessor;
@@ -62,11 +61,8 @@ public class SpaceCreatedNotifcationGeneratingProcessor implements TaskProcessor
                           String datetime,
                           String username) {
 
-        String domain = System.getProperty(ConfigConstants.DURACLOUD_SITE_DOMAIN);
-        if (domain == null) {
-            domain = Constants.DEFAULT_DOMAIN;
-        }
-        String host = subdomain + "." + domain;
+        ConfigurationManager configManager = new ConfigurationManager();
+        String host = configManager.getSubdomainDotDefaultDomain(subdomain);
 
         String subject = "New Space on " + host + ", provider " + storeId + ": " +
                          spaceId;

--- a/workman/src/main/java/org/duracloud/mill/audit/SpaceCreatedNotifcationGeneratingProcessor.java
+++ b/workman/src/main/java/org/duracloud/mill/audit/SpaceCreatedNotifcationGeneratingProcessor.java
@@ -8,6 +8,8 @@
 package org.duracloud.mill.audit;
 
 import org.duracloud.audit.task.AuditTask;
+import org.duracloud.common.constant.Constants;
+import org.duracloud.mill.config.ConfigConstants;
 import org.duracloud.mill.notification.NotificationManager;
 import org.duracloud.mill.workman.TaskExecutionFailedException;
 import org.duracloud.mill.workman.TaskProcessor;
@@ -60,7 +62,12 @@ public class SpaceCreatedNotifcationGeneratingProcessor implements TaskProcessor
                           String datetime,
                           String username) {
 
-        String host = subdomain + ".duracloud.org";
+        String domain = System.getProperty(ConfigConstants.DURACLOUD_SITE_DOMAIN);
+        if (domain == null) {
+            domain = Constants.DEFAULT_DOMAIN;
+        }
+        String host = subdomain + "." + domain;
+
         String subject = "New Space on " + host + ", provider " + storeId + ": " +
                          spaceId;
         StringBuilder body = new StringBuilder();

--- a/workman/src/main/java/org/duracloud/mill/bit/BitIntegrityReportTaskProcessor.java
+++ b/workman/src/main/java/org/duracloud/mill/bit/BitIntegrityReportTaskProcessor.java
@@ -18,6 +18,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.duracloud.common.constant.Constants;
 import org.duracloud.common.retry.Retriable;
 import org.duracloud.common.retry.Retrier;
 import org.duracloud.common.util.ChecksumUtil;
@@ -27,6 +28,7 @@ import org.duracloud.mill.bitlog.BitIntegrityResult;
 import org.duracloud.mill.bitlog.BitLogItem;
 import org.duracloud.mill.bitlog.BitLogStore;
 import org.duracloud.mill.common.taskproducer.TaskProducerConfigurationManager;
+import org.duracloud.mill.config.ConfigConstants;
 import org.duracloud.mill.db.model.BitIntegrityReport;
 import org.duracloud.mill.notification.NotificationManager;
 import org.duracloud.mill.workman.TaskExecutionFailedException;
@@ -184,7 +186,11 @@ public class BitIntegrityReportTaskProcessor extends TaskProcessorBase {
         String storeId = report.getStoreId();
         String spaceId = report.getSpaceId();
 
-        String host = account + ".duracloud.org";
+        String domain = System.getProperty(ConfigConstants.DURACLOUD_SITE_DOMAIN);
+        if (domain == null) {
+            domain = Constants.DEFAULT_DOMAIN;
+        }
+        String host = account + "." + domain;
 
         String subject = "Bit Integrity Report #" + report.getId() + ": errors (count = " +
                          errors.size() + ")  detected on " + host + ", providerId=" + storeId +

--- a/workman/src/main/java/org/duracloud/mill/bit/BitIntegrityReportTaskProcessor.java
+++ b/workman/src/main/java/org/duracloud/mill/bit/BitIntegrityReportTaskProcessor.java
@@ -18,7 +18,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.duracloud.common.constant.Constants;
 import org.duracloud.common.retry.Retriable;
 import org.duracloud.common.retry.Retrier;
 import org.duracloud.common.util.ChecksumUtil;
@@ -28,7 +27,7 @@ import org.duracloud.mill.bitlog.BitIntegrityResult;
 import org.duracloud.mill.bitlog.BitLogItem;
 import org.duracloud.mill.bitlog.BitLogStore;
 import org.duracloud.mill.common.taskproducer.TaskProducerConfigurationManager;
-import org.duracloud.mill.config.ConfigConstants;
+import org.duracloud.mill.config.ConfigurationManager;
 import org.duracloud.mill.db.model.BitIntegrityReport;
 import org.duracloud.mill.notification.NotificationManager;
 import org.duracloud.mill.workman.TaskExecutionFailedException;
@@ -186,11 +185,8 @@ public class BitIntegrityReportTaskProcessor extends TaskProcessorBase {
         String storeId = report.getStoreId();
         String spaceId = report.getSpaceId();
 
-        String domain = System.getProperty(ConfigConstants.DURACLOUD_SITE_DOMAIN);
-        if (domain == null) {
-            domain = Constants.DEFAULT_DOMAIN;
-        }
-        String host = account + "." + domain;
+        ConfigurationManager configManager = new ConfigurationManager();
+        String host = configManager.getSubdomainDotDefaultDomain(account);
 
         String subject = "Bit Integrity Report #" + report.getId() + ": errors (count = " +
                          errors.size() + ")  detected on " + host + ", providerId=" + storeId +


### PR DESCRIPTION
## Testing

### Default behaviour

- Do not change configuration
- Create a space
- Workman should send a "New space created" notification email with `https://<subdomain>.duracloud.org` in the body

### Override behaviour

- Add `duracloud-site.domain=other.domain` to `mill.properties` file
- Restart workman
- Create a space
- Workman should send a "New space created" notification email with `https://<subdomain>.other.domain` in the body