### PR TITLE
Correct the sumo config file's name: sumo.conf not sumo.properties.

### DIFF
--- a/docker/scripts/setup.sh
+++ b/docker/scripts/setup.sh
@@ -8,8 +8,9 @@ sh -xc "sed -i -e '/^127.0.1.1/d' /etc/hosts; echo 127.0.1.1 ${HOST_NAME}.${DOMA
 
 
 # configure sumo
-cp $MILL_HOME/sumo.properties  /opt/SumoCollector/config/user.properties
-echo "\nsources=/opt/app/sumo-sources.json" >> /opt/SumoCollector/config/user.properties
+cp $MILL_HOME/sumo.conf /opt/SumoCollector/config/user.properties
+
+echo "sources=/opt/app/sumo-sources.json" >> /opt/SumoCollector/config/user.properties
 
 # start sumo
 service collector start


### PR DESCRIPTION
Remove unnecessary line break in sumo property configuration.

This update ensures that the sumo collector is able to start up with the sumo credentials and a valid pointer to the sumo sources file in the docker container.