### PR TITLE
Upgrade docker to baseimage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:22.04
+FROM ghcr.io/phusion/baseimage:jammy-1.0.1
 
-RUN apt-get update && apt-get install openjdk-11-jre-headless wget cron -y
-RUN mkdir /opt/app
+RUN apt-get update && apt-get install openjdk-11-jre-headless wget vim telnet -y
+RUN mkdir -p /opt/app
 
 RUN wget -q https://collectors.sumologic.com/rest/download/deb/64 -O SumoCollector.deb && \ 
    chmod +x SumoCollector.deb && \
@@ -19,8 +19,9 @@ ADD loopingduptaskproducer/target/loopingduptaskproducer-${VERSION}.jar /opt/app
 ADD looping-storagestats-taskproducer/target/looping-storagestats-taskproducer-${VERSION}.jar /opt/app/
 ADD storage-reporter/target/storage-reporter-${VERSION}.jar /opt/app/
 ADD loopingbittaskproducer/target/loopingbittaskproducer-${VERSION}.jar /opt/app/
-ADD docker/scripts/* /opt/app/
 ADD docker/resources/sumo_sources.json /opt/
+ADD docker/scripts/* /opt/app/
+ADD docker/startup/* /etc/my_init.d/
 
 ENV LOG_LEVEL=DEBUG
 ENV MILL_VERSION=${VERSION}
@@ -32,4 +33,5 @@ ENV INSTANCE_ID=instance_id
 ENV CONFIG_FILE_PATH="/mill-home/mill-config.properties"
 ENV NODE_TYPE=audit-worker
 ENV MILL_HOME=/mill-home
-CMD [ "sh", "-c", "echo node type = ${NODE_TYPE}; . /opt/app/setup.sh && . /opt/app/${NODE_TYPE}.sh && sleep infinity" ] 
+
+CMD ["/sbin/my_init"]

--- a/docker/scripts/sentinel-crontab
+++ b/docker/scripts/sentinel-crontab
@@ -1,7 +1,7 @@
-5,15,25,35,45,55 * * * *  bash -x /opt/app/auditlog-generator-run.sh
-5,25,45 * * * * bash -x /opt/app/manifest-cleaner-run.sh
-0 * * * * bash -x /opt/app/storage-stats-producer-run.sh
-*/7 * * * *  bash -x /opt/app/bit-producer-run.sh
-57 6 * * 1  bash -x /opt/app/storage-reporter-run.sh
-0 * * * *  bash -x /opt/app/efs-cleanup-run.sh
-0,10,20,30,40,50 * * * *  bash -x /opt/app/dup-producer-run.sh
+5,15,25,35,45,55 * * * *  root flock -n /var/lock/auditlog-generator-run.lock /opt/app/auditlog-generator-run.sh
+5,25,45 * * * * root flock -n /var/lock/manifest-cleaner-run.lock /opt/app/manifest-cleaner-run.sh
+0 * * * * root flock -n /var/lock/storage-stats-producer-run.lock /opt/app/storage-stats-producer-run.sh
+*/7 * * * *  root flock -n /var/lock/bit-producer-run.lock /opt/app/bit-producer-run.sh
+57 6 * * 1  root flock -n /var/lock/storage-reporter-run.lock /opt/app/storage-reporter-run.sh
+0 * * * *  root flock -n /var/lock/efs-cleanup-run.lock /opt/app/efs-cleanup-run.sh
+0,10,20,30,40,50 * * * *  root flock -n /var/lock/dup-producer-run.lock /opt/app/dup-producer-run.sh

--- a/docker/scripts/sentinel.sh
+++ b/docker/scripts/sentinel.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
 
-echo "Enabling cron..."
-service cron restart 
-ln -s /opt/app/sentinel-crontab /etc/cron.d/sentinel-crontab
-crontab /etc/cron.d/sentinel-crontab
-echo "cron enabled."
+echo "Sentinel init script"
+echo "Sentinel init script complete."

--- a/docker/startup/00_startup.sh
+++ b/docker/startup/00_startup.sh
@@ -3,6 +3,15 @@
 # ensure the environment is available in cron jobs
 printenv | grep -v "no_proxy" >> /etc/environment
 
+# ensure the scripts are executable
+chmod u+x /opt/app/*.sh
+
+# set up cron jobs if this is a sentinel node
+if [[ ${NODE_TYPE} == "sentinel" ]]; then
+  ln -s /opt/app/sentinel-crontab /etc/cron/cron.d/sentinel
+fi
+
+# update the hostname in etc hosts
 sh -xc "echo ${HOST_NAME} > /etc/hostname; hostname -F /etc/hostname"
 sh -xc "sed -i -e '/^127.0.1.1/d' /etc/hosts; echo 127.0.1.1 ${HOST_NAME}.${DOMAIN} ${HOST_NAME} >> /etc/hosts"
 
@@ -11,3 +20,7 @@ cp $MILL_HOME/sumo.conf /opt/SumoCollector/config/user.properties
 
 # start sumo
 service collector start
+
+# start the node specific startup script
+
+nohup /opt/app/${NODE_TYPE}.sh &>/dev/null &

--- a/docker/startup/01_startup.sh
+++ b/docker/startup/01_startup.sh
@@ -6,11 +6,6 @@ printenv | grep -v "no_proxy" >> /etc/environment
 # ensure the scripts are executable
 chmod u+x /opt/app/*.sh
 
-# set up cron jobs if this is a sentinel node
-if [[ ${NODE_TYPE} == "sentinel" ]]; then
-  ln -s /opt/app/sentinel-crontab /etc/cron/cron.d/sentinel
-fi
-
 # update the hostname in etc hosts
 sh -xc "echo ${HOST_NAME} > /etc/hostname; hostname -F /etc/hostname"
 sh -xc "sed -i -e '/^127.0.1.1/d' /etc/hosts; echo 127.0.1.1 ${HOST_NAME}.${DOMAIN} ${HOST_NAME} >> /etc/hosts"
@@ -22,5 +17,10 @@ cp $MILL_HOME/sumo.conf /opt/SumoCollector/config/user.properties
 service collector start
 
 # start the node specific startup script
+
+# set up cron jobs if this is a sentinel node
+if [[ ${NODE_TYPE} == "sentinel" ]]; then
+  ln -s /opt/app/sentinel-crontab /etc/cron.d/sentinel
+fi
 
 nohup /opt/app/${NODE_TYPE}.sh &>/dev/null &


### PR DESCRIPTION
This update does a few things: 

1. upgrade docker to use baseimage (the recommended version for ubuntu based docker images.
2. use flock to ensure only one instance of scripts are running (when launched by cron)

These updates have been tested in the dev environment.
