### PR TITLE
Add SWIFT_S3 to list of storage providers to calculate content checksum

### DIFF
--- a/workman/src/main/java/org/duracloud/mill/bit/BitCheckHandler.java
+++ b/workman/src/main/java/org/duracloud/mill/bit/BitCheckHandler.java
@@ -57,6 +57,7 @@ abstract class BitCheckHandler {
      */
     private static void initializeContentChecksumCalculatingStorageProviders() {
         CONTENT_CHECKSUM_CALCULATING_STORAGE_PROVIDERS.add(StorageProviderType.AMAZON_S3);
+        CONTENT_CHECKSUM_CALCULATING_STORAGE_PROVIDERS.add(StorageProviderType.SWIFT_S3);
     }
 
     public final boolean handle(BitCheckExecutionState bitCheckState) throws TaskExecutionFailedException {

--- a/workman/src/test/java/org/duracloud/mill/bit/BitIntegrityCheckTaskProcessorTest.java
+++ b/workman/src/test/java/org/duracloud/mill/bit/BitIntegrityCheckTaskProcessorTest.java
@@ -233,6 +233,11 @@ public class BitIntegrityCheckTaskProcessorTest extends EasyMockSupport {
     }
 
     @Test
+    public void testSuccessWithContentCheckSwift() throws Exception {
+        testSuccess(StorageProviderType.SWIFT_S3, true);
+    }
+
+    @Test
     public void testSuccessWithOutContentCheckGlacier() throws Exception {
         testSuccess(StorageProviderType.AMAZON_GLACIER, false);
     }


### PR DESCRIPTION
### What does this Pull Request do?
Currently, the **content-checksum** column in health check reports for Swift storage provider is blank. The same column is not empty for Amazon S3 storage providers.

PR adds SWIFT_S3 to the list of storage providers to calculate content checksum verifications

### How should this be tested?

#### Prerequisites for testing
Configure a Swift storage provider

#### Steps

1. After configuring a Swift storage provider, create a space and upload objects.
2. Run health check (`loopingbittaskproducer`)
3. Verify that **content-checksum** column in the report is not blank and contains the checksum of the object